### PR TITLE
Fixed syntax issues for api.py

### DIFF
--- a/pineapple/api.py
+++ b/pineapple/api.py
@@ -20,6 +20,6 @@ class API(object):
         resp = requests.post(self.url, data=payload, headers=self.headers)
         try:
             return json.loads(resp.text)
-        except ValueError, e:
-            print 'Error decoding: '+repr(resp.text)
+        except ValueError as e:
+            print("Error decoding: %".format(repr(resp.text)))
             print e


### PR DESCRIPTION
Ran into the following behavior on python 2.7.13 & 3.6.0 on osx
```
In [2]: import pineapple
  File "/Users/maus/python-pineapple/pineapple/api.py", line 24
    print 'Error decoding: '+repr(resp.text)
                           ^
SyntaxError: invalid syntax
```

```
In [1]: from pineapple import *
  File "/Users/maus/python-pineapple/pineapple/api.py", line 23
    except ValueError, e:
                     ^
SyntaxError: invalid syntax
```

Fixed with the attached diff.